### PR TITLE
xacro load made optional xacro_load arg

### DIFF
--- a/allegro_hand/launch/allegro_hand.launch
+++ b/allegro_hand/launch/allegro_hand.launch
@@ -68,6 +68,7 @@
   <arg name="RESPAWN" default="false"/>
 
   <!-- Take xacro file path as an argument, to support alternative robot configurations -->
+  <arg name="load_xacro" default="true"/>  <!-- Should the xacro be loaded? -->
   <arg name="XACRO_PATH" default="$(find allegro_hand_description)/allegro_hand_description_$(arg HAND).xacro" />
 
   <!-- option to (not) publish tf, useful when mounting the hand -->
@@ -75,8 +76,10 @@
 
   <!-- Load the robot description directly from the xacro file. (NOTE: store it
        in two parameter names.) -->
-  <param name="robot_description"
-         command="$(find xacro)/xacro '$(arg XACRO_PATH)' --check-order"/>
+
+  <group if="$(arg load_xacro)">
+        <param name="robot_description" command="xacro --inorder '$(arg XACRO_PATH)' $(arg urdf_args)"/>
+  </group>
 
   <!-- Allegro Hand controller and communication node. -->
   <node name="allegroHand_$(arg HAND)_$(arg NUM)"


### PR DESCRIPTION
added argument to make the load of the xacro file optional.


Having this argument improve the reusability of the launch file which is not loading the xacro file when is not requested to do so. This allows another launch file to call allegro_hand.launch without the risk that the robot description is overwritten.